### PR TITLE
check comment

### DIFF
--- a/test/unit/randomApeYachtClub.test.js
+++ b/test/unit/randomApeYachtClub.test.js
@@ -43,7 +43,7 @@ describe('RAYC', function () {
   describe('withdraw', function() {
     it('the amount of the contract is 0 after withdrawing', async function() {
       await randomApeYachtClub.withdraw();
-      const provider = ethers.provider;
+      const provider = ethers.provider; // fix this as per the PR description, i.e. use ethers.getDefaultProvider
       const balance = await provider.getBalance(randomApeYachtClub.address);
       expect(balance).to.equal(0);
     });


### PR DESCRIPTION
from ethers docs:

ethers.getDefaultProvider( [ network , [ options ] ] ) ⇒ Provider Returns a new Provider, backed by multiple services, connected to network. If no network is provided, homestead (i.e. mainnet) is used.

The network may also be a URL to connect to, such as http://localhost:8545 or wss://example.com.